### PR TITLE
Dockerfile: add python3 expandvars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN cd /root/oe \
   && patch scripts/lib/wic/engine.py 0001-wic-Adjust-cmd-line-format-to-debugfs-1.45.6.patch
 
 RUN apk add python3 py3-pip libffi-dev make openssl-dev gcc libc-dev python3-dev
-RUN pip3 install docker-compose==1.26
+RUN pip3 install docker-compose==1.26 expandvars==0.6.5
 
 ## Stage 2
 FROM docker:dind


### PR DESCRIPTION
This allows us to expand things like ${FACTORY-default} in python code.
It is now required by apps_publisher.py

Signed-off-by: Andy Doan <andy@foundries.io>