### PR TITLE
Fix/ostreeuploader

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,10 +37,9 @@ RUN pip3 install docker-compose==1.27 expandvars==0.6.5
 
 FROM golang:alpine
 RUN apk add gcc git glib-dev make musl-dev
-RUN git clone https://github.com/foundriesio/ostreehub /ostreehub && \
-	cd /ostreehub && git checkout 28589fed069acec05026d94d9450cbd4fe3980b8
-RUN cd /ostreehub && make fiopush && make fiocheck
-
+RUN git clone https://github.com/foundriesio/ostreeuploader.git /ostreeuploader && \
+	cd /ostreeuploader && git checkout 54daa6777667ab9263c65a379453b65d9a2eb19a
+RUN cd /ostreeuploader && make
 
 FROM docker:20.10.2-dind
 WORKDIR /root/
@@ -66,8 +65,8 @@ COPY --from=0 /root/aktualizr/build-git/src/sota_tools/libsota_tools.so /usr/lib
 # install OE core utilities, WIC utility is located here /usr/bin/oe/scripts/wic
 COPY --from=0 /root/oe /usr/bin/oe
 
-COPY --from=1 /ostreehub/bin/fiopush /usr/bin/
-COPY --from=1 /ostreehub/bin/fiocheck /usr/bin/
+COPY --from=1 /ostreeuploader/bin/fiopush /usr/bin/
+COPY --from=1 /ostreeuploader/bin/fiocheck /usr/bin/
 
 CMD bash
 ENTRYPOINT []

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN cd /ostreeuploader && make
 FROM docker:20.10.2-dind
 WORKDIR /root/
 
-RUN apk add --no-cache bash glib libarchive libcurl libsodium nss openjdk8-jre-base ostree python3 boost-program_options boost-log boost-filesystem boost-log_setup parted sgdisk git
+RUN apk add --no-cache bash glib libarchive libcurl libsodium nss openjdk8-jre-base ostree python3 boost-program_options boost-log boost-filesystem boost-log_setup parted sgdisk git lsblk
 RUN wget -O /tmp/docker-app.tgz  https://github.com/docker/app/releases/download/v0.9.0-beta1/docker-app-linux.tar.gz \
 	&& tar xf "/tmp/docker-app.tgz" -C /tmp/ \
 	&& mkdir -p /usr/lib/docker/cli-plugins \


### PR DESCRIPTION
- Use ostreeuploader repo for the fiopush tools. We moved the push/check tools from ostreehub to ostreeuploader project, so this is corresponding change in Dockerfile;
- add `lsblk` utility.
