### PR TITLE
dockerfile: Bump docker compose to v2.20.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY --from=0 /ostreeuploader/bin/fiocheck /usr/bin/
 COPY --from=0 /ostreeuploader/bin/fiosync /usr/bin/
 COPY --from=0 /go/bin/docker-credential-gcr /usr/bin/
 
-RUN wget https://github.com/docker/compose/releases/download/v2.6.0/docker-compose-linux-x86_64 -O /usr/lib/docker/cli-plugins/docker-compose \
+RUN wget https://github.com/docker/compose/releases/download/v2.20.2/docker-compose-linux-x86_64 -O /usr/lib/docker/cli-plugins/docker-compose \
 	&& chmod +x /usr/lib/docker/cli-plugins/docker-compose
 
 CMD bash


### PR DESCRIPTION
Align `docker compose` version in the container with the version in meta-lmp https://github.com/foundriesio/meta-lmp/pull/1247.