### PR TITLE
Add `composectl` utility to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,11 @@ RUN git clone https://github.com/foundriesio/ostreeuploader.git /ostreeuploader 
 RUN cd /ostreeuploader && make
 RUN go install github.com/GoogleCloudPlatform/docker-credential-gcr@v2.0.5+incompatible
 
+FROM golang:1.22.2-bookworm AS composectl
+WORKDIR /build
+RUN git clone https://github.com/foundriesio/composeapp.git && cd composeapp \
+    && git checkout v95 && make
+
 FROM docker:20.10.12-dind
 WORKDIR /root/
 
@@ -34,6 +39,8 @@ COPY --from=0 /ostreeuploader/bin/fiopush /usr/bin/
 COPY --from=0 /ostreeuploader/bin/fiocheck /usr/bin/
 COPY --from=0 /ostreeuploader/bin/fiosync /usr/bin/
 COPY --from=0 /go/bin/docker-credential-gcr /usr/bin/
+COPY --from=composectl /build/composeapp/bin/composectl /usr/bin/
+COPY compose-publish.sh /usr/bin/compose-publish
 
 RUN wget https://github.com/docker/compose/releases/download/v2.20.2/docker-compose-linux-x86_64 -O /usr/lib/docker/cli-plugins/docker-compose \
 	&& chmod +x /usr/lib/docker/cli-plugins/docker-compose

--- a/compose-publish.sh
+++ b/compose-publish.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+composectl publish $@


### PR DESCRIPTION
Add `composectl` utility to the image so it can be used in the CI runs, specifically:

1. To replace the current `compose-publish` utility with `composectl publish` command. It requires setting `PUBLISH_TOOL` to `/usr/bin/compose-publish` in a factory config's container section.

2. To replace `skopeo` with `composectl` to perform different app related functionality, e.g. pull apps for offline update or image preloading.