### PR TITLE
dockerfile: Control layers manifest injection

### DIFF
--- a/compose-publish.sh
+++ b/compose-publish.sh
@@ -1,2 +1,8 @@
 #!/bin/bash
-composectl publish $@
+
+add_layers_manifest=true
+if [ "${OCI_COMPLIANT_APP}" == "1" ]; then
+	add_layers_manifest=false
+fi
+
+composectl publish --layers-manifest=$add_layers_manifest $@


### PR DESCRIPTION
Add an environment variable to control whether to add the layers manifest into an app manifest or not. This allows to produce OCI-compliant app manifest if `OCI_COMPLIANT_APP` is set to `"1"`.

Eventually, it will allows us controlling it through factory configuration once corresponding changes to source.f.io are made.