### PR TITLE
 build(dockerfile): update golang and composeapp versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ RUN git clone https://github.com/foundriesio/ostreeuploader.git /ostreeuploader 
 RUN cd /ostreeuploader && make
 RUN go install github.com/GoogleCloudPlatform/docker-credential-gcr@v2.0.5+incompatible
 
-FROM golang:1.22.2-bookworm AS composectl
+FROM golang:1.22.12-bookworm AS composectl
 WORKDIR /build
 RUN git clone https://github.com/foundriesio/composeapp.git && cd composeapp \
-    && git checkout v95 && CGO_ENABLED=0 make
+    && git checkout v96.0.1 && CGO_ENABLED=0 make
 
 FROM docker:27-dind
 WORKDIR /root/


### PR DESCRIPTION
- Update golang version to 1.22.12-bookworm since newer version of composeapp requires it.
- Update composeapp to version v96.0.1 to include latest features, specifically DockerHub support.